### PR TITLE
Update README.md - add Tested with: A360

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 Python API for Polar devices. Command line interface included.
 
 Tested with:
+* A360
 * Loop
 * M400
 


### PR DESCRIPTION
Polar A360 Activity Tracker works fine - connect, list, dump, get, walk.
'list' issues a "[!] Failed to get extended info.", but that does not seem to be a problem, Manufacturer, Product name, Vendor ID, Product ID and Serial number are shown properly.
